### PR TITLE
Fix to allow font family for a paragraph text to be set and read.

### DIFF
--- a/DocX/Formatting.cs
+++ b/DocX/Formatting.cs
@@ -79,7 +79,7 @@ namespace Novacode
                     case "position": formatting.Position = Int32.Parse(option.GetAttribute(XName.Get("val", DocX.w.NamespaceName))) / 2; break;
                     case "kern": formatting.Position = Int32.Parse(option.GetAttribute(XName.Get("val", DocX.w.NamespaceName))) / 2; break;
                     case "w": formatting.PercentageScale = Int32.Parse(option.GetAttribute(XName.Get("val", DocX.w.NamespaceName))); break;
-                    case "rFonts": break;
+                    case "rFonts": formatting.FontFamily = new FontFamily(option.GetAttribute(XName.Get("cs", DocX.w.NamespaceName))); break;
                     case "vanish": formatting.hidden = true; break;
                     case "b": formatting.Bold = true; break;
                     case "i": formatting.Italic = true; break;

--- a/DocX/Paragraph.cs
+++ b/DocX/Paragraph.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
@@ -2470,6 +2471,16 @@ namespace Novacode
                 return;
             }
 
+          var contentIsListOfFontProperties = false;
+          var fontProps = content as IEnumerable;
+          if (fontProps != null)
+          {
+            foreach (object property in fontProps)
+            {
+              contentIsListOfFontProperties = (property as XAttribute != null);
+            }
+          }
+
             foreach (XElement run in runs)
             {
                 rPr = run.Element(XName.Get("rPr", DocX.w.NamespaceName));
@@ -2481,6 +2492,22 @@ namespace Novacode
 
                 rPr.SetElementValue(textFormatPropName, value);
                 XElement last = rPr.Elements().Last();
+
+              if (contentIsListOfFontProperties) //if content is a list of attributes, as in the case when specifying a font family 
+              {
+                foreach (object property in fontProps)
+                {
+                  if (last.Attribute(((System.Xml.Linq.XAttribute) (property)).Name) == null)
+                  {
+                    last.Add(property); //Add this attribute if element doesn't have it
+                  }
+                  else
+                  {
+                    last.Attribute(((System.Xml.Linq.XAttribute) (property)).Name).Value =
+                      ((System.Xml.Linq.XAttribute) (property)).Value; //Apply value only if element already has it
+                  }
+                }
+              }
 
                 if (content as System.Xml.Linq.XAttribute != null)//If content is an attribute
                 {

--- a/UnitTests/DocXUnitTests.cs
+++ b/UnitTests/DocXUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1787,24 +1788,40 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
-        public void InsertANextPageBreakWithParagraphTextsShouldAddProperParagraphsToProperSections()
+      [TestMethod]
+      public void InsertANextPageBreakWithParagraphTextsShouldAddProperParagraphsToProperSections()
+      {
+        using (DocX document = DocX.Create("SectionPageBreakWithParagraphs.docx"))
         {
-            using (DocX document = DocX.Create("SectionPageBreakWithParagraphs.docx"))
-            {
-                document.InsertParagraph("First paragraph.");
-                document.InsertParagraph("Second paragraph.");
-                document.InsertSectionPageBreak();
-                document.InsertParagraph("Third paragraph.");
-                document.InsertParagraph("Fourth paragraph.");
+          document.InsertParagraph("First paragraph.");
+          document.InsertParagraph("Second paragraph.");
+          document.InsertSectionPageBreak();
+          document.InsertParagraph("Third paragraph.");
+          document.InsertParagraph("Fourth paragraph.");
 
-                var sections = document.GetSections();
-                Assert.AreEqual(sections.Count, 2);
+          var sections = document.GetSections();
+          Assert.AreEqual(sections.Count, 2);
 
-                Assert.AreEqual(sections[0].SectionParagraphs.Count(p => !string.IsNullOrWhiteSpace(p.Text)), 2);
-                Assert.AreEqual(sections[1].SectionParagraphs.Count(p => !string.IsNullOrWhiteSpace(p.Text)), 2);
-                document.Save();
-            }
+          Assert.AreEqual(sections[0].SectionParagraphs.Count(p => !string.IsNullOrWhiteSpace(p.Text)), 2);
+          Assert.AreEqual(sections[1].SectionParagraphs.Count(p => !string.IsNullOrWhiteSpace(p.Text)), 2);
+          document.Save();
         }
+      }
+
+      [TestMethod]
+        public void WhenAFontFamilyIsSpecifiedForAParagraphItShouldSetTheFontOfTheParagraphTextToTheFontFamily()
+        {
+          using (DocX document = DocX.Create("FontTest.docx"))
+          {
+            Paragraph p = document.InsertParagraph();
+
+            p.Append("Hello World").Font(new FontFamily("Century"));
+
+            Assert.AreEqual(p.MagicText[0].formatting.FontFamily.Name, "Century");
+
+            document.Save();
+          }
+        }
+
     }
 }


### PR DESCRIPTION
I have added a fix to enable setting a font family for paragraph text.
