### PR TITLE
fixed index bug in Paragraph.FindAll

### DIFF
--- a/DocX/Container.cs
+++ b/DocX/Container.cs
@@ -319,7 +319,7 @@ namespace Novacode
                 List<int> indexes = p.FindAll(str, options);
 
                 for (int i = 0; i < indexes.Count(); i++)
-                    indexes[0] += p.startIndex;
+                    indexes[i] += p.startIndex;
 
                 list.AddRange(indexes);
             }


### PR DESCRIPTION
the start index was added several times to the first result not once to each result
